### PR TITLE
Move update hook location and clean-up on success

### DIFF
--- a/debian/athena-auto-update
+++ b/debian/athena-auto-update
@@ -185,7 +185,7 @@ fi
 UPDATE_HOOK_URL="https://athena10.mit.edu/update-hook/debathena-update-hook.sh"
 UPDATE_HOOK_SUM="https://athena10.mit.edu/update-hook/debathena-update-hook-sha256sum"
 MITCA="/usr/share/debathena-auto-update/mitCA.crt"
-UPDATE_HOOK="/var/run/debathena-update-hook.sh"
+UPDATE_HOOK="/var/tmp/debathena-update-hook.sh"
 
 rm -f $UPDATE_HOOK
 if [ "$RUN_UPDATE_HOOK" = "yes" ] && \
@@ -208,6 +208,7 @@ if [ "$RUN_UPDATE_HOOK" = "yes" ] && \
 	   exit
        else
 	   touch "/var/lib/athena-update-hooks/$SHA256SUM"
+	   rm -f $UPDATE_HOOK
        fi
    fi
 fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+debathena-auto-update (1.45) unstable; urgency=low
+
+  * Do not attempt to run update hooks out of /var/run, since it's mounted
+    noexec; use /var/tmp instead (Trac: #1461)
+  * Delete the script upon successful execution
+
+ -- Jonathan Reed <jdreed@mit.edu>  Tue, 13 May 2014 15:32:36 -0400
+
 debathena-auto-update (1.44) unstable; urgency=low
 
   * Add git-buildpackage configuration


### PR DESCRIPTION
/run is noexec, so we can't actually execute the update hook, so
we move it to /var/tmp instead (Trac: #1461)

We also clean up the hook upon successful execution
