### PR TITLE
Disable CLEANUP_OLD_KERNELS

### DIFF
--- a/debian/athena-auto-update
+++ b/debian/athena-auto-update
@@ -177,7 +177,7 @@ CLEANUP_OLD_KERNELS=no
 # On cluster machines, force our desired settings
 # Ignore /etc/default/debathena-auto-update
 if dpkg-query --showformat '${Status}\n' -W "debathena-cluster" 2>/dev/null | grep -q ' installed$'; then
-    CLEANUP_OLD_KERNELS=yes
+    CLEANUP_OLD_KERNELS=no
     UPDATE_FORCE_CONFFILE=new
     RUN_UPDATE_HOOK=yes
 fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+debathena-auto-update (1.47) unstable; urgency=low
+
+  * Disable CLEANUP_OLD_KERNELS, because it no longer works on Trusty,
+    because the linux-image-extra-VERSION-generic packages now depend on
+    linux-image-generic, and autoremove it.
+
+ -- Jonathan Reed <jdreed@mit.edu>  Mon, 27 Apr 2015 14:25:10 -0400
+
 debathena-auto-update (1.46) unstable; urgency=low
 
   * Switch back to /var/run and invoke update hook via sh directly.


### PR DESCRIPTION
Because it breaks the world in Trusty, and because as of
raring, the kernel's postinst.d configures APT to allow
autoremove of older kernels